### PR TITLE
Add autorun feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you don't want the buttons at all, you can add
     `def` can be a table containing `code` (or `func`), and optionally `owner`.
     If `persistent` is specified, this snippet will remain registered across
     reboots.
+    If `autorun` is specified, this snippet will auto run on server start. (Snippet must be persistent to support autorun)
  - `snippets.unregister_snippet(name)`: The opposite of
     `snippets.register_snippet`.
  - `snippets.registered_snippets`: A table containing the above snippets.

--- a/init.lua
+++ b/init.lua
@@ -24,3 +24,11 @@ local enable_buttons = minetest.settings:get_bool('snippets.enable_buttons')
 if enable_buttons or enable_buttons == nil then
     dofile(modpath .. '/nodes.lua')
 end
+
+minetest.register_on_mods_loaded(function()
+    for name, def in pairs(snippets.registered_snippets) do
+        if def.autorun then
+            snippets.run(name)
+        end
+    end
+end)

--- a/persistence.lua
+++ b/persistence.lua
@@ -38,6 +38,7 @@ function snippets.register_snippet(name, def)
         storage:set_string('>' .. name, minetest.serialize({
             code = def.code,
             owner = def.owner,
+            autorun = def.autorun
         }))
     end
 


### PR DESCRIPTION
This PR adds possibility to make certain snippets run on server startup. They're executed by `minetest.register_on_mods_loaded` callback.
To enable/disable autorun, click on "Autorun" checkbox to the right of the "Run" button.
Snippets for which autorun is enabled are marked with the `[A]` flag and highlighted in reddish color.
### How to test
* Create any snippet
* Enable the "Autorun" checkbox in this snippet
* Save the snippet
* Rejoin the world / restart server and check if the snippet was executed