### PR TITLE
fix crash on log() in unsaved snippet after owner leaves

### DIFF
--- a/console.lua
+++ b/console.lua
@@ -135,7 +135,12 @@ function snippets.push_console_msg(name, msg, col)
 end
 
 snippets.register_on_log(function(snippet, level, msg)
-    local owner = snippets.registered_snippets[snippet].owner
+    local def = snippets.registered_snippets[snippet]
+    if not def then
+        -- if snippet was not saved, it has no definition stored
+        return
+    end
+    local owner = def.owner
     local form = forms[owner]
     if not owner or not form or not form.context.text or
             not form:is_open() then


### PR DESCRIPTION
If snippet wasn't saved, but triggers `log()` in any way (either directly calling it, or accessing undefined global) when snippet owner is not online, then the formspec logging callback will crash here:
https://github.com/mt-historical/snippets/blob/bf10290b3996fbb3b3ca48c80e8f8fce6d5e423e/console.lua#L137-L138
This is because temporary definition is removed on leave:
https://github.com/mt-historical/snippets/blob/bf10290b3996fbb3b3ca48c80e8f8fce6d5e423e/core.lua#L269-L272

Backtrace:
```
2025-05-05 13:50:35: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod '' in callback item_OnPlace(): .../mods/minetest-snippets/console.lua:138: attempt to index a nil value
2025-05-05 13:50:35: ERROR[Main]: stack traceback:
2025-05-05 13:50:35: ERROR[Main]: 	.../mods/minetest-snippets/console.lua:138: in function 'func'
2025-05-05 13:50:35: ERROR[Main]: 	.../mods/minetest-snippets/core.lua:87: in function 'log'
2025-05-05 13:50:35: ERROR[Main]: 	.../mods/minetest-snippets/core.lua:142: in function 'func'
2025-05-05 13:50:35: ERROR[Main]: 	.../builtin/profiler/instrumentation.lua:124: in function 'callback'
2025-05-05 13:50:35: ERROR[Main]: 	../builtin/game/item.lua:316: in function <../builtin/game/item.lua:144>
```

Steps to reproduce:
- Start server
- Join with first account
- Do `/snippets`, then paste and run this snippet without saving it:
```lua
core.register_on_placenode(function()
  snippets.log('none', "whatever")
end)
```
- Leave the server
- Join with a different account
- Place a block
- Crash